### PR TITLE
Add type hints to action API

### DIFF
--- a/.github/workflows/validate-action-types.yml
+++ b/.github/workflows/validate-action-types.yml
@@ -1,0 +1,15 @@
+name: Validate action typings
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate-typings:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: typesafegithub/github-actions-typing@v1
+

--- a/action-types.yml
+++ b/action-types.yml
@@ -1,0 +1,20 @@
+# See https://github.com/krzema12/github-actions-typing
+
+inputs:
+  mode:
+    type: enum
+    allowed-values:
+      - check-for-approvals
+      - dismiss-stale-reviews
+  path_to_cached_diff:
+    type: string
+  token:
+    type: string
+  diffs_directory:
+    type: string
+  repo_path:
+    type: string
+outputs:
+  approved_sha:
+    type: string
+


### PR DESCRIPTION
Asana task: https://app.asana.com/0/966980249286837/1204518979988852/f
Context: https://medicode.slack.com/archives/C5ZR8V40G/p1683294933138089

# Testing
In my fork: https://github.com/fathom-piotr/dismiss_if_stale/actions/runs/4912910625/jobs/8772477755

```
Overall result: 
✔ VALID

Inputs:
• mode:
  ✔ VALID
• path_to_cached_diff:
  ✔ VALID
• token:
  ✔ VALID
• diffs_directory:
  ✔ VALID
• repo_path:
  ✔ VALID

Outputs:
• approved_sha:
  ✔ VALID
```