### PR TITLE
Use the more granular cache actions

### DIFF
--- a/.github/workflows/cache-approved-diff.yml
+++ b/.github/workflows/cache-approved-diff.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Cache the diff. The cache is scoped to the current branch and the "default"
       # branch aka develop.
-      - uses: actions/cache@v3
+      - uses: actions/cache/save@v3
         with:
           path: approved.diff
           # we key by the commit corresponding to when the PR was approved

--- a/.github/workflows/dismiss-if-stale-review.yml
+++ b/.github/workflows/dismiss-if-stale-review.yml
@@ -59,7 +59,7 @@ jobs:
       # Notably, the cached diff is the only way to reliably know the reviewed diff in
       # the case of the target branch changing because that branch was merged and
       # deleted.
-      - uses: actions/cache@v3
+      - uses: actions/cache/restore@v3
         if: ${{ steps.check.outputs.approved_sha && steps.check.outputs.approved_sha != '' }}
         with:
           path: approved.diff


### PR DESCRIPTION
Reduces unnecessary processing (e.g. no attempt at restoring from cache when you specifically invoke `save`).
