### PR TITLE
ci: cache approval metadata for range-diff comparison

### DIFF
--- a/.github/workflows/cache-approved-diff.yml
+++ b/.github/workflows/cache-approved-diff.yml
@@ -20,16 +20,45 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      # get the diff using gh CLI
-      - run: >
+      # Get the merge base for range-diff comparison
+      - name: Get merge base
+        id: merge-base
+        run: |
+          MERGE_BASE=$(gh api \
+            /repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
+            --jq '.merge_base_commit.sha')
+          echo "sha=$MERGE_BASE" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Create metadata JSON for range-diff comparison
+      - name: Create approval metadata
+        run: |
+          cat > approval-metadata.json << EOF
+          {
+            "version": 1,
+            "approved_sha": "${{ github.event.review.commit_id }}",
+            "merge_base_sha": "${{ steps.merge-base.outputs.sha }}",
+            "base_sha": "${{ github.event.pull_request.base.sha }}",
+            "base_ref": "${{ github.event.pull_request.base.ref }}",
+            "approved_at": "${{ github.event.review.submitted_at }}"
+          }
+          EOF
+
+      # Get the diff using gh CLI (for fallback comparison)
+      - name: Get approved diff
+        run: >
           gh api -H 'Accept: application/vnd.github.diff'
           /repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} > approved.diff
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Cache the diff. The cache is scoped to the current branch and the "default"
+
+      # Cache both files together. The cache is scoped to the current branch and the "default"
       # branch aka develop.
       - uses: actions/cache/save@v3
         with:
-          path: approved.diff
+          path: |
+            approval-metadata.json
+            approved.diff
           # we key by the commit corresponding to when the PR was approved
-          key: ${{ github.event.pull_request.head.sha }}
+          key: approval-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dismiss-if-stale-review.yml
+++ b/.github/workflows/dismiss-if-stale-review.yml
@@ -50,22 +50,28 @@ jobs:
       pull-requests: write
 
     steps:
+      # Checkout with full history for git range-diff
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - id: check
         uses: ./
         with:
           mode: check-for-approvals
-      # Try to restore the approved diff from the cache.
-      # Notably, the cached diff is the only way to reliably know the reviewed diff in
+      # Try to restore the approved diff and metadata from the cache.
+      # Notably, the cached data is the only way to reliably know the reviewed diff in
       # the case of the target branch changing because that branch was merged and
       # deleted.
       - uses: actions/cache/restore@v3
         if: ${{ steps.check.outputs.approved_sha && steps.check.outputs.approved_sha != '' }}
         with:
-          path: approved.diff
-          key: ${{ steps.check.outputs.approved_sha }}
+          path: |
+            approval-metadata.json
+            approved.diff
+          key: approval-${{ steps.check.outputs.approved_sha }}
       - uses: ./
         if: ${{ steps.check.outputs.approved_sha && steps.check.outputs.approved_sha != '' }}
         with:
           mode: dismiss-stale-reviews
+          # path_to_cached_metadata: approval-metadata.json  # TODO: enable when action supports it
           path_to_cached_diff: approved.diff


### PR DESCRIPTION
Asana task: https://app.asana.com/1/186294513059342/project/1160856459640233/task/1204482911884564?focus=true

Add metadata JSON caching to the approval workflow. This stores:
- approved_sha: The commit that was approved
- merge_base_sha: The merge base at time of approval
- base_sha/base_ref: Base branch info
- approved_at: Timestamp

This metadata will be used by a future range-diff implementation to more
accurately detect stale reviews (and address existing flakiness in the dismiss-if-stale workflow). The existing diff caching is maintained for compatibility.

Also adds fetch-depth: 0 to checkout and updates cache key prefix.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

Notable impact of this change: since the cache key is changing, PRs which were approved prior this change deploying and then getting pushed may have their approvals dismissed.